### PR TITLE
docker-compose를 활용하여 redis 컨테이너 사용

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,22 @@
 
 Java : 17  
 Spring Boot : 2.7.5  
+
+### docker-compose를 활용하여 redis 사용하기
+```bash
+
+# 도커 컴포즈를 활용하여 redis 컨테이너 실행
+## 백그라운드 실행 시 -d 옵션 추가
+## 레디스 옵션 설정하려면 ./container/conf/redis.conf 를 수정
+docker-compose -f ./container/redis.yml up # -d
+
+## 실행된 도커 프로세스 확인
+docker ps     
+CONTAINER ID   IMAGE         COMMAND                  CREATED         STATUS         PORTS                    NAMES
+97213b72da1e   redis:7.0.5   "docker-entrypoint.s…"   6 seconds ago   Up 4 seconds   0.0.0.0:6379->6379/tcp   redis-server
+
+# 레디스 컨테이너가 실행된 뒤 redis-cli를 통해 레디스에 접속
+docker exec -it redis-server redis-cli
+
+$127.0.0.1:6379>
+```

--- a/container/redis.yml
+++ b/container/redis.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  redis:
+    container_name: redis-server
+    image: redis:7.0.5
+    restart: always
+    ports:
+      - "6379:6379"
+    command: redis-server /usr/local/conf/redis.conf
+    volumes:
+      - ./conf/redis.conf:/usr/local/conf/redis.conf


### PR DESCRIPTION
### ❗️ 이슈 번호

#1 

<br><br>

### 📝 구현 내용

도커 컴포르를 활용하여 redis 컨테이너 사용
- redis version 7.0.5
- port 6379
- redis.conf 설정 가능
- 실행 문서 작성


### 사용 방법

```bash
# 도커 컴포즈를 활용하여 redis 컨테이너 실행
## 백그라운드 실행 시 -d 옵션 추가
## 레디스 옵션 설정하려면 ./container/conf/redis.conf 를 수정
docker-compose -f ./container/redis.yml up # -d
## 실행된 도커 프로세스 확인
docker ps     
CONTAINER ID   IMAGE         COMMAND                  CREATED         STATUS         PORTS                    NAMES
97213b72da1e   redis:7.0.5   "docker-entrypoint.s…"   6 seconds ago   Up 4 seconds   0.0.0.0:6379->6379/tcp   redis-server
# 레디스 컨테이너가 실행된 뒤 redis-cli를 통해 레디스에 접속
docker exec -it redis-server redis-cli
$127.0.0.1:6379>
```

### 결과

![image](https://user-images.githubusercontent.com/57086195/202894961-eddcccdf-a0d9-43a6-80ae-c7e75d36d485.png)
