### PR TITLE
Testconatiners를 활용하여 redis 사용하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,63 @@ docker exec -it redis-server redis-cli
 
 $127.0.0.1:6379>
 ```
+
+---
+
+### Testcontainers를 활용하여 redis 사용하기
+
+1. Testcontainers 의존성 추가
+
+```
+# build.gradle
+
+dependencies {
+	// ...
+  
+	// TestContainers
+	testImplementation 'org.testcontainers:junit-jupiter:1.17.4'
+}
+```
+
+2. TestContainers에서 권장하는 logback 설정
+
+```
+# ./src/test/resources/logback-test.xml 
+## ref : https://www.testcontainers.org/supported_docker_environment/logging_config/
+
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>
+```
+
+3. redis 컨테이너 실행과 확인
+
+```java
+// ./test/java/com/example/redis/RedisContainerTest.java
+@Testcontainers
+class RedisTestContaners {
+
+	@Container
+	public GenericContainer redis = new GenericContainer("redis:7.0.5")
+			.withExposedPorts(6379);
+
+	@Test
+	void testContainers_실행확인() {
+		assertThat(redis.getHost()).isEqualTo("localhost");
+		assertThat(redis.getExposedPorts()).contains(6379);
+	}
+}
+```

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,18 @@ repositories {
 }
 
 dependencies {
+	// spring web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// TestContainers
+	testImplementation 'org.testcontainers:junit-jupiter:1.17.4'
 }
 
 tasks.named('test') {

--- a/src/test/java/kim/ku/redis/testcontainers/RedisTestContaners.java
+++ b/src/test/java/kim/ku/redis/testcontainers/RedisTestContaners.java
@@ -1,0 +1,22 @@
+package kim.ku.redis.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class RedisTestContaners {
+
+	@Container
+	public GenericContainer redis = new GenericContainer("redis:7.0.5")
+			.withExposedPorts(6379);
+
+	@Test
+	void testContainers_실행확인() {
+		assertThat(redis.getHost()).isEqualTo("localhost");
+		assertThat(redis.getExposedPorts()).contains(6379);
+	}
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
### ❗️ 이슈 번호

#2 

<br><br>

### 📝 구현 내용

- Testcontainers 의존성 추가
- Testcontainers 권장 logback 추가
- 테스트에 Testcontainers를 활용하여 redis 컨테이너 생성
- 사용 방법 문서 작성


### 결과

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/57086195/202896024-8059d89d-9c9c-43f2-9bab-fa5cb41a2741.png">
