### PR TITLE
Testconatiners를 활용하여 띄운 redis를 테스트 환경에서 사용하기

### DIFF
--- a/src/test/java/kim/ku/redis/testcontainers/TestContainerRedisConnectionTest.java
+++ b/src/test/java/kim/ku/redis/testcontainers/TestContainerRedisConnectionTest.java
@@ -1,0 +1,38 @@
+package kim.ku.redis.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import kim.ku.redis.config.RedisRepositoryConfig;
+import kim.ku.redis.domain.Point;
+import kim.ku.redis.domain.PointRedisRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@Import(RedisRepositoryConfig.class)
+@ActiveProfiles("testcontainers")
+class TestContainerRedisConnectionTest extends TestContainersRedisTest{
+
+	@Autowired
+	private PointRedisRepository pointRedisRepository;
+
+	@AfterEach
+	void tearDown() {
+		pointRedisRepository.deleteAll();
+	}
+
+	@Test
+	void 기본_조회() {
+		pointRedisRepository.save(new Point("1", 100L, LocalDateTime.now()));
+
+		Point point = pointRedisRepository.findById("1").get();
+
+		assertThat(point.getAmount()).isEqualTo(100L);
+	}
+
+}

--- a/src/test/java/kim/ku/redis/testcontainers/TestContainersRedisTest.java
+++ b/src/test/java/kim/ku/redis/testcontainers/TestContainersRedisTest.java
@@ -8,7 +8,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class TestContanersRedisTest {
+class TestContainersRedisTest {
 
 	@Container
 	public GenericContainer redis = new GenericContainer("redis:7.0.5")
@@ -19,4 +19,5 @@ class TestContanersRedisTest {
 		assertThat(redis.getHost()).isEqualTo("localhost");
 		assertThat(redis.getExposedPorts()).contains(6379);
 	}
+
 }

--- a/src/test/resources/application-testcontainers.yml
+++ b/src/test/resources/application-testcontainers.yml
@@ -1,0 +1,4 @@
+spring:
+  redis:
+    host: localhost
+    port: 6379


### PR DESCRIPTION
### ❗️ 이슈 번호

#1

<br><br>

### 📝 구현 내용

- 기존 테스트 컨테이너를 활용하여 컨테이너만 띄운것을 spring data redis를 활용하여 해당 redis 연결하여 사용 



### 💡 참고 자료

![image](https://user-images.githubusercontent.com/57086195/205922857-e6daa6aa-353d-4d9d-ac66-445f69480923.png)