### PR TITLE
Redis에서 Transaction에 관한 학습과 이전에 구현한 Rate Limit에 트랜잭션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	// Spring Data Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc' // Jdbc, Driver
+
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
@@ -36,6 +38,9 @@ dependencies {
 
 	// Embedded Redis DB
 	testImplementation 'it.ozimov:embedded-redis:0.7.3' exclude group: 'org.slf4j', module: 'slf4j-simple'
+
+	// Embedded RDB H2
+	implementation 'com.h2database:h2'
 
 	// TestContainers
 	testImplementation 'org.testcontainers:junit-jupiter:1.17.4'

--- a/src/main/java/kim/ku/redis/config/RedisConfiguration.java
+++ b/src/main/java/kim/ku/redis/config/RedisConfiguration.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 //@EnableRedisRepositories
-@EnableTransactionManagement
+//@EnableTransactionManagement
 public class RedisConfiguration {
 
 	@Value("${spring.redis.host}")

--- a/src/main/java/kim/ku/redis/config/RedisConfiguration.java
+++ b/src/main/java/kim/ku/redis/config/RedisConfiguration.java
@@ -1,16 +1,24 @@
 package kim.ku.redis.config;
 
+import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EnableRedisRepositories
+//@EnableRedisRepositories
+@EnableTransactionManagement
 public class RedisConfiguration {
 
 	@Value("${spring.redis.host}")
@@ -30,6 +38,30 @@ public class RedisConfiguration {
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setEnableTransactionSupport(true);
 		return redisTemplate;
+	}
+
+	/*
+	https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/#tx
+	 */
+	@Bean
+	public StringRedisTemplate stringRedisTemplate() {
+		StringRedisTemplate template = new StringRedisTemplate(redisConnectionFactory());
+		// explicitly enable transaction support
+		template.setEnableTransactionSupport(true);
+		return template;
+	}
+
+	@Bean
+	public PlatformTransactionManager transactionManager() {
+		return new DataSourceTransactionManager(dataSource());
+	}
+
+	@Bean(name = "datasource")
+	@Primary
+	@ConfigurationProperties(prefix = "spring.datasource")
+	public DataSource dataSource() {
+		return DataSourceBuilder.create().build();
 	}
 }

--- a/src/main/java/kim/ku/redis/ratelimit/service/RateLimitService.java
+++ b/src/main/java/kim/ku/redis/ratelimit/service/RateLimitService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +21,7 @@ public class RateLimitService {
 	public static final int API_MAXIMUN_COUNT = 30;
 	private final StringRedisTemplate redisTemplate;
 
-
+	@Transactional
 	public boolean isAllowed(String clientIp) {
 		long apiCount = getApiCount(clientIp);
 

--- a/src/main/java/kim/ku/redis/transaction/TransactionService.java
+++ b/src/main/java/kim/ku/redis/transaction/TransactionService.java
@@ -1,0 +1,38 @@
+package kim.ku.redis.transaction;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+	private final StringRedisTemplate stringRedisTemplate;
+	private final RedisTemplate redisTemplate;
+
+	@Transactional
+	public void stringRedisTemplateCheckRollback() {
+		stringRedisTemplate.opsForValue().set("key11", "value11");
+		stringRedisTemplate.opsForValue().set("key22", "value22");
+		System.out.println(stringRedisTemplate.opsForValue().get("key11")); // 레디스는 트랜잭션에서 null 나오는 것 확인용
+
+		if (true) {
+			throw new RuntimeException("예외 발생");
+		}
+	}
+
+	@Transactional
+	public void redisTemplateCheckRollback() {
+		redisTemplate.opsForValue().set("key11", "value11");
+		redisTemplate.opsForValue().set("key22", "value22");
+		System.out.println(stringRedisTemplate.opsForValue().get("key11"));
+
+		if (true) {
+			throw new RuntimeException("예외 발생");
+		}
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,17 @@ spring:
   redis:
     host: localhost
     port: 6379
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    jdbc-url: jdbc:h2:mem:testdb;
+    username: sa
+    password: 1234
+  h2:
+    console:
+      enabled: true
+
+sql:
+  init:
+    mode: always
+    encoding: UTF-8

--- a/src/test/java/kim/ku/redis/transaction/RedisTransactionTest.java
+++ b/src/test/java/kim/ku/redis/transaction/RedisTransactionTest.java
@@ -1,0 +1,113 @@
+package kim.ku.redis.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SpringBootTest
+class RedisTransactionTest {
+
+	@Autowired
+	private RedisTemplate redisTemplate;
+
+	@Autowired
+	private StringRedisTemplate stringRedisTemplate;
+
+	@Autowired
+	private TransactionService transactionService;
+
+	@AfterEach
+	void setUp() {
+		stringRedisTemplate.execute(new RedisCallback() {
+			@Override
+			public Object doInRedis(RedisConnection connection) throws DataAccessException {
+				connection.flushAll();
+				return null;
+			}
+		});
+	}
+
+	@Test
+	void multi_exec_트랜잭션확인() {
+
+		// given
+		stringRedisTemplate.execute(new SessionCallback() {
+			@Override
+			public Object execute(RedisOperations operations) throws DataAccessException {
+				operations.multi(); // 트랜잭션 시작
+
+				operations.opsForValue().set("key1", "value1");
+				operations.opsForValue().set("key2", "value2");
+
+				return operations.exec(); // 종료
+			}
+		});
+
+		String value1 = stringRedisTemplate.opsForValue().get("key1");
+		String value2 = stringRedisTemplate.opsForValue().get("key2");
+
+		assertThat(value1).isEqualTo("value1");
+		assertThat(value2).isEqualTo("value2");
+	}
+
+	@Test
+	void multi_exec_명령어_트랜잭션_확인2() {
+
+		// given : 중간에 비정상적으로 실패하면 데이터 업데이트 적용안됨
+		assertThatThrownBy(() -> stringRedisTemplate.execute(new SessionCallback() {
+			@Override
+			public Object execute(RedisOperations operations) throws DataAccessException {
+				operations.multi(); // 트랜잭션 시작
+
+				operations.opsForValue().set("key1", "value1");
+				operations.opsForValue().set("key2", "value2");
+
+				if (true) {
+					throw new RuntimeException("예외 발생");
+				}
+				return operations.exec(); // 종료
+			}
+		})).isInstanceOf(RuntimeException.class);
+
+		String value1 = stringRedisTemplate.opsForValue().get("key1");
+		String value2 = stringRedisTemplate.opsForValue().get("key2");
+
+		assertThat(value1).isNull();
+		assertThat(value2).isNull();
+	}
+
+	@Test
+	void transaction_어노테이션활용하여_트랜잭션_확인_stringredistemplate() {
+		assertThatThrownBy(() -> transactionService.stringRedisTemplateCheckRollback()).isInstanceOf(
+			RuntimeException.class);
+
+		String value1 = stringRedisTemplate.opsForValue().get("key11");
+		String value2 = stringRedisTemplate.opsForValue().get("key22");
+
+		assertThat(value1).isNull();
+		assertThat(value2).isNull();
+	}
+
+	@Test
+	void transaction_어노테이션활용하여_트랜잭션_확인_redistemplate() {
+		assertThatThrownBy(() -> transactionService.redisTemplateCheckRollback()).isInstanceOf(
+			RuntimeException.class);
+
+		Object value1 = redisTemplate.opsForValue().get("key11");
+		Object value2 = redisTemplate.opsForValue().get("key22");
+
+		assertThat(value1).isNull();
+		assertThat(value2).isNull();
+	}
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

#11
#9

<br><br>

### 📝 구현 내용

-  redis command (multi / exec) 을 활용한 트랜잭션과 롤백
-  `@Transactional` 어노테이션을 활용한 트랜잭션과 롤백
    - 레디스에서  @트랜잭션 사용하려면 JDBC나 JPA의 트랜잭션 매니저에 붙여서 사용해야 합니다. 따라서 서비스에서 레디스만 사용하고 트랜잭션 매니저가 없다면 @트랜잭션을 사용못하고 직접 redis 트랜잭션(multi/exec)를 써야합니다.
    - JDBC 트랜잭션 매니저를 사용하기 위해 H2를 활용하여 Datasource를 생성하고 트랜잭션 매니저를 붙였습니다.
- +a) lua script만 쓴다면 트랜젝션 단위이기 때문에  괜찮을듯합니다
- 이전 #10 기능에 트랜잭션 기능 추가

### 💡 참고 자료

![image](https://user-images.githubusercontent.com/57086195/206216373-42d0e18b-9eec-4908-8d4f-3c7bf60b8720.png)