### PR TITLE
테라폼을 활용한 ElastiCache 프로비저닝

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,38 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+Footer

--- a/infra/elasticache/.terraform.lock.hcl
+++ b/infra/elasticache/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.45.0"
+  hashes = [
+    "h1:ZFb6RqY48Fe+18sOC62wiE38XYPaTg98RJZO+EnsvCU=",
+    "zh:22da03786f25658a000d1bcc28c780816a97e7e8a1f59fff6eee7d452830e95e",
+    "zh:2543be56eee0491eb0c79ca1c901dcbf71da26625961fe719f088263fef062f4",
+    "zh:31a1da1e3beedfd88c3c152ab505bdcf330427f26b75835885526f7bb75c4857",
+    "zh:4409afe50f225659d5f378fe9303a45052953a1219f7f1acc82b69d07528b7ba",
+    "zh:4dadec3b783f10d2f8eef3dab5e817baae9c932a7967d45fe3d77fcbcbdaa438",
+    "zh:55be80d6e24828dcb0db7a0226fb275415c1c0ad63dd2f33b76f3ac0cd64e6a6",
+    "zh:560bba29efb7dbe0bfcc937369d88817aa31a8d18aa25395b1afe2576cb04495",
+    "zh:6caacc202e83438ff63d5d96733e283f44e349668d96c6b1c5c7df463ebf85cc",
+    "zh:6cabab83a61d5b4ac801c5a5d57556a0e76ec8dc879d28cf777509db5f6a657e",
+    "zh:96c4528bf9c16edb8841b68479ec51c499ed7fa680462fa28caeab3fc168bb43",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cdc0b47ff840d708fbf75abfe86d23dc7f1dffdd233a771822a17b5c637f4769",
+    "zh:d9a9583e82776d1ebb6cf6c3d47acc2b302f8778f470ceffe7579dc794eb1feb",
+    "zh:e9367ca9f6f6418a23cdf8d01f29dd0c4f614e78499f52a767a422e4c334b915",
+    "zh:f6d355a2fb3bcebb597f68bbca4fa2aaa364efd29240236c582375e219d77656",
+  ]
+}

--- a/infra/elasticache/elasticache.tf
+++ b/infra/elasticache/elasticache.tf
@@ -29,6 +29,9 @@ resource "aws_elasticache_cluster" "redis-terraform-test" {
   parameter_group_name = "default.redis7" # 파라미터 그룹
   engine_version       = "7.0" # 레디스 버전
   port                 = 6379
+  security_group_ids = [
+    aws_security_group.infra_test_redis_security_group.id
+  ]
 
   subnet_group_name    = aws_elasticache_subnet_group.infra_test_vpc_subnet_group.name
 }

--- a/infra/elasticache/elasticache.tf
+++ b/infra/elasticache/elasticache.tf
@@ -1,0 +1,37 @@
+#### ref : https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#redis-cluster-mode-disabled-read-replica-instance
+# create vpc
+resource "aws_vpc" "infra_test_vpc" {
+  cidr_block = "10.1.0.0/16"
+}
+
+# create subnet
+resource "aws_subnet" "infra_test_vpc_subnet" {
+  vpc_id     = aws_vpc.infra_test_vpc.id
+  cidr_block = "10.1.1.0/24"
+
+  tags = {
+    Name = "infra-test-subnet"
+  }
+}
+
+# elasticache에 subnet group 연결
+resource "aws_elasticache_subnet_group" "infra_test_vpc_subnet_group" {
+  name       = "test-cache-subnet"
+  subnet_ids = [aws_subnet.infra_test_vpc_subnet.id]
+}
+
+# create elasticache (redis)
+resource "aws_elasticache_cluster" "redis-terraform-test" {
+  cluster_id           = "redis-terraform-test"
+  engine               = "redis"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = 1 # node 1개
+  parameter_group_name = "default.redis7" # 파라미터 그룹
+  engine_version       = "7.0" # 레디스 버전
+  port                 = 6379
+
+  subnet_group_name    = aws_elasticache_subnet_group.infra_test_vpc_subnet_group.name
+}
+
+#### replication group 디테일한 설정하려면 : https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group
+#### 미구현

--- a/infra/elasticache/iam.tf
+++ b/infra/elasticache/iam.tf
@@ -1,0 +1,67 @@
+#### create iam user
+resource "aws_iam_user" "infra-users" {
+  count = length(var.users)
+  name = element(var.users, count.index)
+  path = "/infra/"
+
+  tags = {
+    Name = "infra-developers"
+  }
+}
+
+#### -------------------------------------
+#### create iam group
+resource "aws_iam_group" "infra_group" {
+  name = "infra_Group"
+  path = "/users/"
+}
+
+resource "aws_iam_group_policy_attachment" "infra_group_policy_attach" {
+  #name = aws_iam_group.be_group.name
+
+  group = aws_iam_group.infra_group.name
+
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+
+resource "aws_iam_user_group_membership" "infra_group_membership" {
+  count = length(var.users)
+
+  user = element(var.users, count.index)
+
+  groups = [
+    aws_iam_group.infra_group.name
+  ]
+}
+
+#### -------------------------------------
+#### add iam policy
+resource "aws_iam_user_policy" "art_devops_black" {
+  name = "s3_images_access"
+  count = length(var.users)
+  user = aws_iam_user.infra-users[count.index].name
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "elasticache:*",
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": "iam:CreateServiceLinkedRole",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::*:role/aws-service-role/elasticache.amazonaws.com/AWSServiceRoleForElastiCache",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": "elasticache.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/infra/elasticache/main.tf
+++ b/infra/elasticache/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/infra/elasticache/security_group.tf
+++ b/infra/elasticache/security_group.tf
@@ -1,0 +1,25 @@
+# ecs에서 사용할 보안그룹
+resource "aws_security_group" "infra_test_redis_security_group" {
+  name = "infra-test-redis-security-group"
+
+  vpc_id = aws_vpc.infra_test_vpc.id
+
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
+  tags = {
+    Name = "infra"
+  }
+}

--- a/infra/elasticache/variables.tf
+++ b/infra/elasticache/variables.tf
@@ -1,0 +1,9 @@
+# iam 유저 생성 목록
+variable "users" {
+  description = "Create IAM Users"
+
+  type        = list
+
+  default     = ["infra-kukim"] # n명의 유저를 생성하려면 리스트에 데이터를 추가하세요
+  # default     = ["infra-user1", "infra-user2", ...]
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

#13

<br><br>

### 📝 구현 내용
 이 PR은 테라폼을 활용하여 ElastiCache를 프로비저닝 하는 예 입니다. (iam, vpc, subnet, security group, elasticache)  
ElastiCache는 기본적으로 private subnet으로 외부 통신이 통제되며 같은 vpc ec2에서만 접근가능합니다.  
ec2는 프로비저닝하지 않습니다.

#### ElastiCache 프로비저닝 (iam, VPC, subnet, security group, elasticache)
```bash
# infra/elasticache 디렉토리에 있다는 가정하에
terraform init 

terraform plan

terraform apply
```
![image](https://user-images.githubusercontent.com/57086195/206380156-38725485-7f1f-414f-bb15-69e4e5a59d4a.png)


#### ec2에서 연결 확인
- 전제 조건 : 사용할 ec2는 사전에 Elasticache와 같은 vpc에 있고 이미 만들어져있다고 가정합니다.

![image](https://user-images.githubusercontent.com/57086195/206379698-8a0ccc4c-53f2-47c2-9750-20acae3495e5.png)


#### 자원 제거
```bash
# infra/elasticache 디렉토리에 있다는 가정하에
terraform destroy
```

![image](https://user-images.githubusercontent.com/57086195/206379742-962881f9-9482-4802-b04b-602f1b2fe067.png)

<br><br>


### 💡 참고 자료

- AWS Console 
  - [https://docs.aws.amazon.com/ko_kr/AmazonElastiCache/latest/red-ug/GettingStarted.html](https://docs.aws.amazon.com/ko_kr/AmazonElastiCache/latest/red-ug/GettingStarted.html)
- ec2에서 elasticach 연결
  - https://docs.aws.amazon.com/ko_kr/AmazonElastiCache/latest/red-ug/GettingStarted.ConnectToCacheNode.html
  - https://devlog-wjdrbs96.tistory.com/314
- 테라폼 프로비저닝
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#redis-log-delivery-configuration
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group